### PR TITLE
Fixed stand-alone vs "integrated" mode

### DIFF
--- a/premake/premake5.lua
+++ b/premake/premake5.lua
@@ -1,4 +1,4 @@
--- glfw premake script v1.0
+-- glfw premake script v1.1
 -- Benjamin Sherwood, 2025
 
 -- assume that if we're calling this premake file we are NOT building glfw "individually"
@@ -17,74 +17,71 @@ newoption
     trigger = "stand-alone",
     description = "generates a workspace for the library, enabling it to be built individually"
 }
-workspaceName = "*"
-filter "options:stand-alone"
-    workspaceName = "glfw"
-filter {}
 
-workspace (workspaceName)
-    filter "options:stand-alone"
-        configurations { "Release" }
+if  _OPTIONS["stand-alone"] then
+    workspace "glfw"
         platforms { "Windows" }
+        configurations { "Release" }
+end
+
+project "glfw"
+    location "../build/"
+    kind "StaticLib"
+    language "C"
+    architecture "x64"
+
+    targetdir "%{prj.location}/bin/%{cfg.platform}/%{cfg.buildcfg}"
+    objdir "%{prj.location}/obj/%{cfg.platform}/%{cfg.buildcfg}"
+    debugdir "%{prj.location}/bin/%{cfg.platform}/%{cfg.buildcfg}"
+
+    staticruntime "on"
+
+    filter "configurations:Debug"
+        runtime "Debug"
+    filter "configurations:Release"
+        runtime "Release"
     filter {}
-    project "glfw"
-        location "../build/"
-        kind "StaticLib"
-        language "C"
-        architecture "x64"
 
-        targetdir "%{prj.location}/bin/%{cfg.platform}/%{cfg.buildcfg}"
-        objdir "%{prj.location}/obj/%{cfg.platform}/%{cfg.buildcfg}"
-        debugdir "%{prj.location}/bin/%{cfg.platform}/%{cfg.buildcfg}"
+    defines { "_CRT_SECURE_NO_WARNINGS" }
 
-        staticruntime "on"
+    includedirs { "../include/" }
 
-        filter "configurations:Debug"
-            runtime "Debug"
-        filter "configurations:Release"
-            runtime "Release"
-        filter {}
+    -- to be quite frank; I'm not entirely sure how I came up with this list of
+    -- "platform agnostic" files... but it seems to be correct!
+    files
+    {
+        "../src/glfw_config.h",
+        "../src/context.c",
+        "../src/init.c",
+        "../src/input.c",
+        "../src/monitor.c",
+        "../src/vulkan.c",
+        "../src/window.c",
+        "../src/platform.c",
+        "../src/null_init.c",
+        "../src/null_monitor.c",
+        "../src/null_window.c",
+        "../src/null_joystick.c",
+    }
 
-        defines { "_CRT_SECURE_NO_WARNINGS" }
+    -- now we need to handle platform-specific files...
+    -- these filters will be updated as more platforms are added!
 
-        includedirs { "../include/" }
+    filter "platforms:Windows"
+        defines { "_GLFW_WIN32" }
 
-        -- to be quite frank; I'm not entirely sure how I came up with this list of
-        -- "platform agnostic" files... but it seems to be correct!
+        -- we can use wildcard matching to get all the win32 specific files...
+        -- similar to the note above, I'm not 100% sure how the windows specific files
+        -- were determined... or if they're all necessary!
+        --
+        -- I only make use of OpenGL (for now) so the other files might not be needed,
+        -- but for the sake of completeness this works!
         files
         {
-            "../src/glfw_config.h",
-            "../src/context.c",
-            "../src/init.c",
-            "../src/input.c",
-            "../src/monitor.c",
-            "../src/vulkan.c",
-            "../src/window.c",
-            "../src/platform.c",
-            "../src/null_init.c",
-            "../src/null_monitor.c",
-            "../src/null_window.c",
-            "../src/null_joystick.c",
+            "../src/win32*.c",
+            "../src/wgl_context.c",
+            "../src/egl_context.c",
+            "../src/osmesa_context.c"
         }
 
-        -- now we need to handle platform-specific files...
-        -- these filters will be updated as more platforms are added!
-
-        filter "platforms:Windows"
-            defines { "_GLFW_WIN32" }
-
-            -- we can use wildcard matching to get all the win32 specific files...
-            -- similar to the note above, I'm not 100% sure how the windows specific files
-            -- were determined... or if they're all necessary!
-            --
-            -- I only make use of OpenGL (for now) so the other files might not be needed,
-            -- but for the sake of completeness this works!
-            files
-            {
-                "../src/win32*.c",
-                "../src/wgl_context.c",
-                "../src/egl_context.c",
-                "../src/osmesa_context.c"
-            }
-
-        filter{}
+    filter{}


### PR DESCRIPTION
Fixes #1... now the "--stand-alone" option works as expected.

Now, when the  "--stand-alone" option is used, a default workspace name of  "glfw" is used.

If the premake file is instead included in another project's premake file (i.e. it's being built as a dependency) it simply creates the  project and not the workspace!